### PR TITLE
Improve info

### DIFF
--- a/src/components/modals/tabs/DonateTab.svelte
+++ b/src/components/modals/tabs/DonateTab.svelte
@@ -16,12 +16,14 @@
   let timer;
   let extrinsic;
   let estimatedFee;
+  let insufficientBalance = false;
   let message;
 
   const debounce = (value) => {
     input = value;
     extrinsic = null;
     estimatedFee = null;
+    insufficientBalance = false;
 
     if (!value) return;
     
@@ -40,8 +42,10 @@
       let amountWithFee = amount.add(paymentInfo.partialFee);
 
       // check for insufficient balance
-      if (amountWithFee.cmp(balance) > 0) 
+      if (amountWithFee.cmp(balance) > 0) {
+        insufficientBalance = true;
         return;
+      }
 
       extrinsic = localExtrinsic;
       estimatedFee = formatBalance(paymentInfo.partialFee, {
@@ -111,7 +115,12 @@
   <div
     class="ksm-text-xs ksm-text-paragraph ksm-leading-loose ksm-mb-2"
     class:ksm-hidden={!estimatedFee}>
-    Fees of {estimatedFee} will be applied to the submission
+    Fees of {estimatedFee} will be applied to the transaction.
+  </div>
+  <div
+    class="ksm-text-xs ksm-text-paragraph ksm-leading-loose ksm-mb-2"
+    class:ksm-hidden={!insufficientBalance}>
+    Please enter an amount smaller than your available balance.
   </div>
   <button
     class="ksm-flex ksm-py-2 ksm-px-6 ksm-mx-auto ksm-mt-4 ksm-text-white

--- a/src/components/modals/tabs/ProposeTipTab.svelte
+++ b/src/components/modals/tabs/ProposeTipTab.svelte
@@ -124,19 +124,17 @@
 <form on:submit|preventDefault={onSubmit}>
   <div
     class="ksm-text-xs ksm-text-paragraph ksm-leading-loose ksm--mt-2 ksm-mb-2">
-    Here you can propose a tip from the Kusama Treasury. If you're not a member of the Council, a small bond is required in order to propose a tip. How the final tip amount is calculated, as well as other
+    <p>Here you can propose a tip from the Kusama Treasury. If you're not a member of the Council, a small bond is required in order to propose a tip. How the final tip amount is calculated, as well as other
     details, can be found <a
-      href="https://wiki.polkadot.network/docs/en/learn-treasury#tipping"
+      href="https://guide.kusama.network/docs/en/mirror-learn-treasury#tipping"
       target=" _blank"
       rel="noopener noreferrer"
-      class="ksm-underline">here</a>.
+      class="ksm-underline">here</a>.</p>
+    <p>The URL of this webpage will be added to your message.</p>
   </div>
   {#if isCouncilMember}
     <div class="ksm-flex ksm-justify-between ksm-mt-2 ksm-leading-loose">
       <span class="ksm-text-xs ksm-text-paragraph">Amount {tokenSymbol ? `(${tokenSymbol})` : ''}</span>
-      <span
-        class="ksm-text-xs ksm-text-paragraph"
-        class:invisible={!balance}>Available: {balance && balance.toHuman()}</span>
     </div>
     <input
       type="text"


### PR DESCRIPTION
See individual commits. Note that the constants `api.consts.treasury.tipReportDepositBase` and `api.consts.treasury.dataDepositPerByte` have been moved to `api.consts.tips.*` in more recent versions of the API, though the widget broke when I tried updating the dependency.